### PR TITLE
sqlite::open() takes an AsRef<Path> value

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -14,10 +14,10 @@ pub struct Database<'l> {
 
 impl<'l> Database<'l> {
     /// Open a connection to a new or existing database.
-    pub fn open(path: &Path) -> Result<Database<'l>> {
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Database<'l>> {
         let mut raw = 0 as *mut _;
         unsafe {
-            success!(ffi::sqlite3_open_v2(path_to_c_str!(path), &mut raw,
+            success!(ffi::sqlite3_open_v2(path_to_c_str!(path.as_ref()), &mut raw,
                                           ffi::SQLITE_OPEN_CREATE | ffi::SQLITE_OPEN_READWRITE,
                                           0 as *const _));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 
 /// Open a connection to a new or existing database.
 #[inline]
-pub fn open<'l>(path: &std::path::Path) -> Result<Database<'l>> {
+pub fn open<'l, P: std::convert::AsRef<std::path::Path>>(path: P) -> Result<Database<'l>> {
     Database::open(path)
 }
 


### PR DESCRIPTION
Now we can pass either a string or a Path to it, just like to [std::fs::File::open()](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.open).