### PR TITLE
Implement sqlite3_column_name and helper function to return column names

### DIFF
--- a/src/statement.rs
+++ b/src/statement.rs
@@ -57,16 +57,16 @@ impl<'l> Statement<'l> {
 
     /// Return the name of a column in the statement
     #[inline]
-    pub fn column_name(&self, i: usize) -> String {
+    pub fn column_name(&self, i: usize) -> &str {
         unsafe {
             let ret = ffi::sqlite3_column_name(self.raw.0, i as c_int);
-            c_str_to_string!(ret)
+            c_str_to_str!(ret).unwrap()
         }
     }
 
     /// Return column names in the statement
     #[inline]
-    pub fn column_names(&self) -> Vec<String> {
+    pub fn column_names(&self) -> Vec<&str> {
         (0..self.columns()).map(|i| self.column_name(i)).collect()
     }
 

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -55,16 +55,17 @@ impl<'l> Statement<'l> {
         unsafe { ffi::sqlite3_column_count(self.raw.0) as usize }
     }
 
-    /// Return the name of a column in the statement
+    /// Return the name of a column.
     #[inline]
     pub fn column_name(&self, i: usize) -> &str {
+        debug_assert!(i < self.columns(), format!("column position has to be between 0 and {}", self.columns() - 1));
         unsafe {
             let ret = ffi::sqlite3_column_name(self.raw.0, i as c_int);
             c_str_to_str!(ret).unwrap()
         }
     }
 
-    /// Return column names in the statement
+    /// Return column names.
     #[inline]
     pub fn column_names(&self) -> Vec<&str> {
         (0..self.columns()).map(|i| self.column_name(i)).collect()

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -55,6 +55,21 @@ impl<'l> Statement<'l> {
         unsafe { ffi::sqlite3_column_count(self.raw.0) as usize }
     }
 
+    /// Return the name of a column in the statement
+    #[inline]
+    pub fn column_name(&self, i: usize) -> String {
+        unsafe {
+            let ret = ffi::sqlite3_column_name(self.raw.0, i as c_int);
+            c_str_to_string!(ret)
+        }
+    }
+
+    /// Return column names in the statement
+    #[inline]
+    pub fn column_names(&self) -> Vec<String> {
+        (0..self.columns()).map(|i| self.column_name(i)).collect()
+    }
+
     /// Return the type of a column.
     ///
     /// The type is revealed after the first step has been taken.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -137,10 +137,14 @@ fn cursor_workflow() {
 #[test]
 fn statement_columns() {
     let connection = setup_users(":memory:");
-    let statement = "SELECT * FROM users";
+    let statement = "SELECT id, name, age, photo as user_photo FROM users";
     let mut statement = ok!(connection.prepare(statement));
 
     assert_eq!(statement.columns(), 4);
+
+    let column_names = statement.column_names();
+    assert_eq!(column_names, vec!["id", "name", "age", "user_photo"]);
+    assert_eq!("user_photo", statement.column_name(3));
 
     assert_eq!(ok!(statement.next()), State::Row);
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -142,9 +142,11 @@ fn statement_columns() {
 
     assert_eq!(statement.columns(), 4);
 
-    let column_names = statement.column_names();
-    assert_eq!(column_names, vec!["id", "name", "age", "user_photo"]);
-    assert_eq!("user_photo", statement.column_name(3));
+    {
+        let column_names = statement.column_names();
+        assert_eq!(column_names, vec!["id", "name", "age", "user_photo"]);
+        assert_eq!("user_photo", statement.column_name(3));
+    }
 
     assert_eq!(ok!(statement.next()), State::Row);
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -137,20 +137,26 @@ fn cursor_workflow() {
 #[test]
 fn statement_columns() {
     let connection = setup_users(":memory:");
-    let statement = "SELECT id, name, age, photo as user_photo FROM users";
+    let statement = "SELECT * FROM users";
     let mut statement = ok!(connection.prepare(statement));
-
-    assert_eq!(statement.columns(), 4);
-
-    {
-        let column_names = statement.column_names();
-        assert_eq!(column_names, vec!["id", "name", "age", "user_photo"]);
-        assert_eq!("user_photo", statement.column_name(3));
-    }
 
     assert_eq!(ok!(statement.next()), State::Row);
 
     assert_eq!(statement.columns(), 4);
+}
+
+#[test]
+fn statement_column_name() {
+    let connection = setup_users(":memory:");
+    let statement = "SELECT id, name, age, photo as user_photo FROM users";
+    let statement = ok!(connection.prepare(statement));
+
+    assert_eq!(statement.columns(), 4);
+
+    let column_names = statement.column_names();
+    assert_eq!(column_names, vec!["id", "name", "age", "user_photo"]);
+    assert_eq!("user_photo", statement.column_name(3));
+
 }
 
 #[test]


### PR DESCRIPTION
I think I should add a boundary check in column_name, what do you think? If yes, which error should I use?