### PR TITLE
Add function to open a read only connection

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -33,6 +33,24 @@ impl Connection {
         })
     }
 
+    /// Open a read-only connection to an existing database.
+    pub fn open_readonly<T: AsRef<Path>>(path: T) -> Result<Connection> {
+        let mut raw = 0 as *mut _;
+        unsafe {
+            ok!(ffi::sqlite3_open_v2(
+                path_to_cstr!(path.as_ref()).as_ptr(),
+                &mut raw,
+                ffi::SQLITE_OPEN_READONLY,
+                0 as *const _,
+            ));
+        }
+        Ok(Connection {
+            raw: raw,
+            busy_callback: None,
+            phantom: PhantomData,
+        })
+    }
+
     /// Execute a statement without processing the resulting rows if any.
     #[inline]
     pub fn execute<T: AsRef<str>>(&self, statement: T) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,6 +303,12 @@ pub fn open<T: AsRef<std::path::Path>>(path: T) -> Result<Connection> {
     Connection::open(path)
 }
 
+/// Open a read-only connection to an existing database.
+#[inline]
+pub fn open_readonly<T: AsRef<std::path::Path>>(path: T) -> Result<Connection> {
+    Connection::open_readonly(path)
+}
+
 /// Return the version number of SQLite.
 ///
 /// For instance, the version `3.8.11.1` corresponds to the integer `3008011`.


### PR DESCRIPTION
This just adds a new function `Connection::open_readonly` to open an existing database in read only mode.