### PR TITLE
Introduce connection flags

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -12,7 +12,7 @@ pub struct Connection {
     phantom: PhantomData<ffi::sqlite3>,
 }
 
-/// A set of connection flags.
+/// Flags for opening a database connection.
 #[derive(Clone, Copy, Debug)]
 pub struct OpenFlags(c_int);
 
@@ -24,7 +24,7 @@ impl Connection {
         Connection::open_with_flags(path, OpenFlags::new().set_create().set_read_write())
     }
 
-    /// Open a database connection with a specific set of flags.
+    /// Open a database connection with specific flags.
     pub fn open_with_flags<T: AsRef<Path>>(path: T, flags: OpenFlags) -> Result<Connection> {
         let mut raw = 0 as *mut _;
         unsafe {
@@ -158,7 +158,7 @@ impl Drop for Connection {
 }
 
 impl OpenFlags {
-    /// Create a set of connection flags.
+    /// Create flags for opening a database connection.
     #[inline]
     pub fn new() -> Self {
         OpenFlags(0)

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -14,18 +14,18 @@ pub struct Connection {
 
 /// A set of connection flags.
 #[derive(Clone, Copy, Debug)]
-pub struct ConnectionFlags(c_int);
+pub struct OpenFlags(c_int);
 
 unsafe impl Send for Connection {}
 
 impl Connection {
     /// Open a read-write connection to a new or existing database.
     pub fn open<T: AsRef<Path>>(path: T) -> Result<Connection> {
-        Connection::open_with_flags(path, ConnectionFlags::new().set_create().set_read_write())
+        Connection::open_with_flags(path, OpenFlags::new().set_create().set_read_write())
     }
 
-    /// Open a database connection with a specific set of connection flags.
-    pub fn open_with_flags<T: AsRef<Path>>(path: T, flags: ConnectionFlags) -> Result<Connection> {
+    /// Open a database connection with a specific set of flags.
+    pub fn open_with_flags<T: AsRef<Path>>(path: T, flags: OpenFlags) -> Result<Connection> {
         let mut raw = 0 as *mut _;
         unsafe {
             ok!(ffi::sqlite3_open_v2(
@@ -157,11 +157,11 @@ impl Drop for Connection {
     }
 }
 
-impl ConnectionFlags {
+impl OpenFlags {
     /// Create a set of connection flags.
     #[inline]
     pub fn new() -> Self {
-        ConnectionFlags(0)
+        OpenFlags(0)
     }
 
     /// Create the database if it does not already exist.

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -188,7 +188,7 @@ impl ConnectionFlags {
 
     /// Open the database for reading only.
     pub fn set_read_only(mut self) -> Self {
-        self.0 |= ffi::SQLITE_OPEN_READWRITE;
+        self.0 |= ffi::SQLITE_OPEN_READONLY;
         self
     }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -12,35 +12,26 @@ pub struct Connection {
     phantom: PhantomData<ffi::sqlite3>,
 }
 
+/// A set of connection flags.
+#[derive(Clone, Copy, Debug)]
+pub struct ConnectionFlags(c_int);
+
 unsafe impl Send for Connection {}
 
 impl Connection {
-    /// Open a connection to a new or existing database.
+    /// Open a read-write connection to a new or existing database.
     pub fn open<T: AsRef<Path>>(path: T) -> Result<Connection> {
-        let mut raw = 0 as *mut _;
-        unsafe {
-            ok!(ffi::sqlite3_open_v2(
-                path_to_cstr!(path.as_ref()).as_ptr(),
-                &mut raw,
-                ffi::SQLITE_OPEN_CREATE | ffi::SQLITE_OPEN_READWRITE,
-                0 as *const _,
-            ));
-        }
-        Ok(Connection {
-            raw: raw,
-            busy_callback: None,
-            phantom: PhantomData,
-        })
+        Connection::open_with_flags(path, ConnectionFlags::new().set_create().set_read_write())
     }
 
-    /// Open a read-only connection to an existing database.
-    pub fn open_readonly<T: AsRef<Path>>(path: T) -> Result<Connection> {
+    /// Open a database connection with a specific set of connection flags.
+    pub fn open_with_flags<T: AsRef<Path>>(path: T, flags: ConnectionFlags) -> Result<Connection> {
         let mut raw = 0 as *mut _;
         unsafe {
             ok!(ffi::sqlite3_open_v2(
                 path_to_cstr!(path.as_ref()).as_ptr(),
                 &mut raw,
-                ffi::SQLITE_OPEN_READONLY,
+                flags.0,
                 0 as *const _,
             ));
         }
@@ -163,6 +154,32 @@ impl Drop for Connection {
     fn drop(&mut self) {
         self.remove_busy_handler();
         unsafe { ffi::sqlite3_close(self.raw) };
+    }
+}
+
+impl ConnectionFlags {
+    /// Create a set of connection flags.
+    #[inline]
+    pub fn new() -> Self {
+        ConnectionFlags(0)
+    }
+
+    /// Create the database if it does not already exist.
+    pub fn set_create(mut self) -> Self {
+        self.0 |= ffi::SQLITE_OPEN_CREATE;
+        self
+    }
+
+    /// Open the database for reading only.
+    pub fn set_read_only(mut self) -> Self {
+        self.0 |= ffi::SQLITE_OPEN_READWRITE;
+        self
+    }
+
+    /// Open the database for reading and writing.
+    pub fn set_read_write(mut self) -> Self {
+        self.0 |= ffi::SQLITE_OPEN_READWRITE;
+        self
     }
 }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -170,6 +170,22 @@ impl ConnectionFlags {
         self
     }
 
+    /// Open the database in the serialized [threading mode][1].
+    ///
+    /// [1]: https://www.sqlite.org/threadsafe.html
+    pub fn set_full_mutex(mut self) -> Self {
+        self.0 |= ffi::SQLITE_OPEN_FULLMUTEX;
+        self
+    }
+
+    /// Opens the database in the multi-thread [threading mode][1].
+    ///
+    /// [1]: https://www.sqlite.org/threadsafe.html
+    pub fn set_no_mutex(mut self) -> Self {
+        self.0 |= ffi::SQLITE_OPEN_NOMUTEX;
+        self
+    }
+
     /// Open the database for reading only.
     pub fn set_read_only(mut self) -> Self {
         self.0 |= ffi::SQLITE_OPEN_READWRITE;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,19 +294,23 @@ mod cursor;
 mod statement;
 
 pub use connection::Connection;
+pub use connection::ConnectionFlags;
 pub use cursor::Cursor;
 pub use statement::{Bindable, Readable, State, Statement};
 
-/// Open a connection to a new or existing database.
+/// Open a read-write connection to a new or existing database.
 #[inline]
 pub fn open<T: AsRef<std::path::Path>>(path: T) -> Result<Connection> {
     Connection::open(path)
 }
 
-/// Open a read-only connection to an existing database.
+/// Open a connection to a database with a specific set of connection flags.
 #[inline]
-pub fn open_readonly<T: AsRef<std::path::Path>>(path: T) -> Result<Connection> {
-    Connection::open_readonly(path)
+pub fn open_with_flags<T: AsRef<std::path::Path>>(
+    path: T,
+    flags: ConnectionFlags,
+) -> Result<Connection> {
+    Connection::open_with_flags(path, flags)
 }
 
 /// Return the version number of SQLite.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,7 +294,7 @@ mod cursor;
 mod statement;
 
 pub use connection::Connection;
-pub use connection::ConnectionFlags;
+pub use connection::OpenFlags;
 pub use cursor::Cursor;
 pub use statement::{Bindable, Readable, State, Statement};
 
@@ -304,12 +304,9 @@ pub fn open<T: AsRef<std::path::Path>>(path: T) -> Result<Connection> {
     Connection::open(path)
 }
 
-/// Open a connection to a database with a specific set of connection flags.
+/// Open a connection to a database with a specific set of flags.
 #[inline]
-pub fn open_with_flags<T: AsRef<std::path::Path>>(
-    path: T,
-    flags: ConnectionFlags,
-) -> Result<Connection> {
+pub fn open_with_flags<T: AsRef<std::path::Path>>(path: T, flags: OpenFlags) -> Result<Connection> {
     Connection::open_with_flags(path, flags)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,12 +304,6 @@ pub fn open<T: AsRef<std::path::Path>>(path: T) -> Result<Connection> {
     Connection::open(path)
 }
 
-/// Open a connection to a database with a specific set of flags.
-#[inline]
-pub fn open_with_flags<T: AsRef<std::path::Path>>(path: T, flags: OpenFlags) -> Result<Connection> {
-    Connection::open_with_flags(path, flags)
-}
-
 /// Return the version number of SQLite.
 ///
 /// For instance, the version `3.8.11.1` corresponds to the integer `3008011`.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -49,7 +49,7 @@ fn connection_open_with_flags() {
     setup_users(&path);
 
     let flags = OpenFlags::new().set_read_only();
-    let connection = ok!(sqlite::open_with_flags(path, flags));
+    let connection = ok!(Connection::open_with_flags(path, flags));
     match connection.execute("INSERT INTO users VALUES (2, 'Bob', NULL, NULL)") {
         Err(_) => {}
         _ => unreachable!(),

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,7 @@
 extern crate sqlite;
 extern crate temporary;
 
-use sqlite::{Connection, State, Type, Value};
+use sqlite::{Connection, ConnectionFlags, State, Type, Value};
 use std::path::Path;
 
 macro_rules! ok(($result:expr) => ($result.unwrap()));
@@ -38,6 +38,22 @@ fn connection_iterate() {
         true
     }));
     assert!(done);
+}
+
+#[test]
+fn connection_open_with_flags() {
+    use temporary::Directory;
+
+    let directory = ok!(Directory::new("sqlite"));
+    let path = directory.path().join("database.sqlite3");
+    setup_users(&path);
+
+    let flags = ConnectionFlags::new().set_read_only();
+    let connection = ok!(sqlite::open_with_flags(path, flags));
+    match connection.execute("INSERT INTO users VALUES (2, 'Bob', NULL, NULL)") {
+        Err(_) => {},
+        _ => unreachable!(),
+    }
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,7 @@
 extern crate sqlite;
 extern crate temporary;
 
-use sqlite::{Connection, ConnectionFlags, State, Type, Value};
+use sqlite::{Connection, OpenFlags, State, Type, Value};
 use std::path::Path;
 
 macro_rules! ok(($result:expr) => ($result.unwrap()));
@@ -48,10 +48,10 @@ fn connection_open_with_flags() {
     let path = directory.path().join("database.sqlite3");
     setup_users(&path);
 
-    let flags = ConnectionFlags::new().set_read_only();
+    let flags = OpenFlags::new().set_read_only();
     let connection = ok!(sqlite::open_with_flags(path, flags));
     match connection.execute("INSERT INTO users VALUES (2, 'Bob', NULL, NULL)") {
-        Err(_) => {},
+        Err(_) => {}
         _ => unreachable!(),
     }
 }


### PR DESCRIPTION
See #16.

Two design choices have been considered:

```rust
// 1. a set of connection flags
let flags = ConnectionFlags::new().set_bla();
let connection = Connection::open_with_flags(path, flags);

// 2. a connection builder
let connection = ConnectionBuilder::new().set_bla().open(path);
```

I have decided for the former in order to avoid creating tension with the existing `set_` methods.

Any feedback is very much welcome.