### PR TITLE
Expose sqlite3_changes() and sqlite3_total_changes()

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -108,6 +108,24 @@ impl Connection {
         ::statement::new(self.raw, statement)
     }
 
+    /// Return the number of rows modified, inserted or deleted by the most recently completed
+    /// INSERT, UPDATE or DELETE statement.
+    #[inline]
+    pub fn changes(&self) -> usize {
+        unsafe {
+            ffi::sqlite3_changes(self.raw) as usize
+        }
+    }
+
+    /// This function returns the total number of rows inserted, modified or deleted by all INSERT,
+    /// UPDATE or DELETE statements completed since the database connection was opened.
+    #[inline]
+    pub fn total_changes(&self) -> usize {
+        unsafe {
+            ffi::sqlite3_total_changes(self.raw) as usize
+        }
+    }
+
     /// Set a callback for handling busy events.
     ///
     /// The callback is triggered when the database cannot perform an operation

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -41,6 +41,27 @@ fn connection_iterate() {
 }
 
 #[test]
+fn connection_changes() {
+    let connection = setup_users(":memory:");
+
+    // The insert in setup_users() counts as a change
+    assert_eq!(connection.changes(), 1);
+    assert_eq!(connection.total_changes(), 1);
+
+    ok!(connection.execute("UPDATE users SET name = 'Bob' WHERE id = 1"));
+    assert_eq!(connection.changes(), 1);
+    assert_eq!(connection.total_changes(), 2);
+
+    ok!(connection.execute("INSERT INTO users VALUES (2, 'Bob', NULL, NULL)"));
+    assert_eq!(connection.changes(), 1);
+    assert_eq!(connection.total_changes(), 3);
+
+    ok!(connection.execute("DELETE FROM users"));
+    assert_eq!(connection.changes(), 2);
+    assert_eq!(connection.total_changes(), 5);
+}
+
+#[test]
 fn connection_open_with_flags() {
     use temporary::Directory;
 


### PR DESCRIPTION
`sqlite3_changes()` is primarily useful to see if the most recent INSERT/UPDATE/DELETE query had an effect. I don't have an immediate use case for `sqlite3_total_changes()`, but it exists and has a similar interface, so I figured I might as well add that too.