### PR TITLE
Implement support for binding named parameters 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "sqlite"
 version = "0.25.3"
 license = "Apache-2.0/MIT"
 authors = [
+    "Alec Moskvin <alecm@gmx.com>",
     "Daniel Dulaney <ddy@vitronic.com>",
     "Ivan Stankovic <pokemon@fly.srk.fer.hr>",
     "Ivan Ukhov <ivan.ukhov@gmail.com>",

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -10,7 +10,9 @@ pub struct Cursor<'l> {
 }
 
 impl<'l> Cursor<'l> {
-    /// Bind values to all parameters.
+    /// Bind values to parameters by index.
+    ///
+    /// The index of each value is assumed to be the value’s position in the array.
     pub fn bind(&mut self, values: &[Value]) -> Result<()> {
         self.state = None;
         self.statement.reset()?;
@@ -20,33 +22,34 @@ impl<'l> Cursor<'l> {
         Ok(())
     }
 
-    /// Bind values to all named parameters.
+    /// Bind values to parameters by name.
     ///
-    /// Any parameters provided that are not part of the statement will be ignored.
+    /// Parameters that are not part of the statement will be ignored.
     ///
     /// # Examples
+    ///
     /// ```
     /// # use sqlite::Value;
     /// # let connection = sqlite::open(":memory:").unwrap();
     /// # connection.execute("CREATE TABLE users (id INTEGER, name STRING)");
     /// let statement = connection.prepare("INSERT INTO users VALUES (:id, :name)")?;
     /// let mut cursor = statement.cursor();
-    /// cursor.bind_params(vec![
+    /// cursor.bind_by_name(vec![
     ///     (":name", Value::String("Bob".to_owned())),
     ///     (":id", Value::Integer(42)),
     /// ])?;
     /// cursor.next()?;
     /// # Ok::<(), sqlite::Error>(())
     /// ```
-    pub fn bind_params<S, V>(&mut self, values: V) -> Result<()>
+    pub fn bind_by_name<S, V>(&mut self, values: V) -> Result<()>
     where
         S: AsRef<str>,
         V: IntoIterator<Item = (S, Value)>,
     {
         self.state = None;
         self.statement.reset()?;
-        for (param, value) in values {
-            if let Some(i) = self.statement.parameter_index(param.as_ref())? {
+        for (name, value) in values {
+            if let Some(i) = self.statement.parameter_index(name.as_ref())? {
                 self.statement.bind(i, &value)?;
             }
         }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -47,7 +47,7 @@ impl<'l> Cursor<'l> {
         self.statement.reset()?;
         for (param, value) in values {
             if let Some(i) = self.statement.parameter_index(param.as_ref())? {
-                self.statement.bind(i.get(), &value)?;
+                self.statement.bind(i, &value)?;
             }
         }
         Ok(())

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -41,7 +41,7 @@ pub trait Readable: Sized {
 }
 
 impl<'l> Statement<'l> {
-    /// Bind a value to a parameter.
+    /// Bind a value to a parameter by index.
     ///
     /// The leftmost parameter has the index 1.
     #[inline]
@@ -49,17 +49,18 @@ impl<'l> Statement<'l> {
         value.bind(self, i)
     }
 
-    /// Bind a value to a named parameter.
+    /// Bind a value to a parameter by name.
     ///
     /// # Examples
+    ///
     /// ```
     /// # let connection = sqlite::open(":memory:").unwrap();
     /// # connection.execute("CREATE TABLE users (name STRING)");
     /// let mut statement = connection.prepare("SELECT * FROM users WHERE name = :name")?;
-    /// statement.bind_param(":name", "Bob")?;
+    /// statement.bind_by_name(":name", "Bob")?;
     /// # Ok::<(), sqlite::Error>(())
     /// ```
-    pub fn bind_param<T: Bindable>(&mut self, name: &str, value: T) -> Result<()> {
+    pub fn bind_by_name<T: Bindable>(&mut self, name: &str, value: T) -> Result<()> {
         if let Some(i) = self.parameter_index(name)? {
             self.bind(i, value)
         } else {

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -50,6 +50,24 @@ impl<'l> Statement<'l> {
         value.bind(self, i)
     }
 
+    /// Bind a value to a named parameter.
+    ///
+    /// # Examples
+    /// ```
+    /// # let connection = sqlite::open(":memory:").unwrap();
+    /// # connection.execute("CREATE TABLE users (name STRING)");
+    /// let mut statement = connection.prepare("SELECT * FROM users WHERE name = :name")?;
+    /// statement.bind_param(":name", "Bob")?;
+    /// # Ok::<(), sqlite::Error>(())
+    /// ```
+    pub fn bind_param<T: Bindable>(&mut self, name: &str, value: T) -> Result<()> {
+        if let Some(i) = self.parameter_index(name)? {
+            self.bind(i.get(), value)
+        } else {
+            raise!(format!("no such parameter: {}", name))
+        }
+    }
+
     /// Return the number of columns.
     #[inline]
     pub fn count(&self) -> usize {
@@ -94,7 +112,7 @@ impl<'l> Statement<'l> {
     /// ```
     /// # let connection = sqlite::open(":memory:").unwrap();
     /// # connection.execute("CREATE TABLE users (name STRING)");
-    /// let statement = connection.prepare("SELECT * FROM users WHERE name = :name").unwrap();
+    /// let statement = connection.prepare("SELECT * FROM users WHERE name = :name")?;
     /// assert_eq!(statement.parameter_index(":name")?.unwrap().get(), 1);
     /// assert_eq!(statement.parameter_index(":asdf")?, None);
     /// # Ok::<(), sqlite::Error>(())

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -294,7 +294,7 @@ fn statement_bind_param_multi() {
     let query = "SELECT name FROM users WHERE age > :age - 5 AND age < :age + 5";
 
     let mut statement = ok!(connection.prepare(query));
-    let index = ok!(statement.parameter_index(":age")).unwrap().get();
+    let index = ok!(statement.parameter_index(":age")).unwrap();
 
     ok!(statement.bind(index, 40));
     let mut cursor = statement.cursor();

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -283,30 +283,6 @@ fn statement_bind_by_name_multiple() {
 }
 
 #[test]
-fn statement_parameter_index() {
-    let connection = setup_users(":memory:");
-    let statement = "INSERT INTO users VALUES (:id, :name, :age, :photo, :email)";
-    let mut statement = ok!(connection.prepare(statement));
-
-    ok!(statement.bind(ok!(statement.parameter_index(":id")).unwrap().into(), 2i64));
-    ok!(statement.bind(
-        ok!(statement.parameter_index(":name")).unwrap().into(),
-        "Bob"
-    ));
-    ok!(statement.bind(
-        ok!(statement.parameter_index(":age")).unwrap().into(),
-        69.42
-    ));
-    ok!(statement.bind(
-        ok!(statement.parameter_index(":photo")).unwrap().into(),
-        &[0x69u8, 0x42u8][..]
-    ));
-    ok!(statement.bind(ok!(statement.parameter_index(":email")).unwrap().into(), ()));
-    assert_eq!(ok!(statement.parameter_index(":missing")), None);
-    assert_eq!(ok!(statement.next()), State::Done);
-}
-
-#[test]
 fn statement_count() {
     let connection = setup_users(":memory:");
     let statement = "SELECT * FROM users";
@@ -345,6 +321,30 @@ fn statement_kind() {
     assert_eq!(statement.kind(1), Type::String);
     assert_eq!(statement.kind(2), Type::Float);
     assert_eq!(statement.kind(3), Type::Binary);
+}
+
+#[test]
+fn statement_parameter_index() {
+    let connection = setup_users(":memory:");
+    let statement = "INSERT INTO users VALUES (:id, :name, :age, :photo, :email)";
+    let mut statement = ok!(connection.prepare(statement));
+
+    ok!(statement.bind(ok!(statement.parameter_index(":id")).unwrap().into(), 2i64));
+    ok!(statement.bind(
+        ok!(statement.parameter_index(":name")).unwrap().into(),
+        "Bob"
+    ));
+    ok!(statement.bind(
+        ok!(statement.parameter_index(":age")).unwrap().into(),
+        69.42
+    ));
+    ok!(statement.bind(
+        ok!(statement.parameter_index(":photo")).unwrap().into(),
+        &[0x69u8, 0x42u8][..]
+    ));
+    ok!(statement.bind(ok!(statement.parameter_index(":email")).unwrap().into(), ()));
+    assert_eq!(ok!(statement.parameter_index(":missing")), None);
+    assert_eq!(ok!(statement.next()), State::Done);
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,6 +3,7 @@ extern crate temporary;
 
 use sqlite::{Connection, OpenFlags, State, Type, Value};
 use std::path::Path;
+use std::collections::HashMap;
 
 macro_rules! ok(($result:expr) => ($result.unwrap()));
 
@@ -159,6 +160,22 @@ fn cursor_wildcard_with_binding() {
         count += 1;
     }
     assert_eq!(count, 6);
+}
+
+#[test]
+fn cursor_bind_params_map() {
+    let connection = ok!(sqlite::open(":memory:"));
+    ok!(connection.execute("CREATE TABLE users (id INTEGER, name STRING)"));
+
+    let statement = ok!(connection.prepare("INSERT INTO users VALUES (:id, :name)"));
+
+    let mut map = HashMap::new();
+    map.insert(":name".to_string(), Value::String("Bob".to_string()));
+    map.insert(":id".to_string(), Value::Integer(42));
+
+    let mut cursor = statement.cursor();
+    ok!(cursor.bind_params(map));
+    assert_eq!(ok!(cursor.next()), None);
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -332,15 +332,15 @@ fn statement_parameter_index() {
     ok!(statement.bind(ok!(statement.parameter_index(":id")).unwrap().into(), 2i64));
     ok!(statement.bind(
         ok!(statement.parameter_index(":name")).unwrap().into(),
-        "Bob"
+        "Bob",
     ));
     ok!(statement.bind(
         ok!(statement.parameter_index(":age")).unwrap().into(),
-        69.42
+        69.42,
     ));
     ok!(statement.bind(
         ok!(statement.parameter_index(":photo")).unwrap().into(),
-        &[0x69u8, 0x42u8][..]
+        &[0x69u8, 0x42u8][..],
     ));
     ok!(statement.bind(ok!(statement.parameter_index(":email")).unwrap().into(), ()));
     assert_eq!(ok!(statement.parameter_index(":missing")), None);


### PR DESCRIPTION
This is useful for queries that take a large number of parameters or if the query is not hard-coded.