### PR TITLE
Support binding of String and String refs

### DIFF
--- a/src/statement.rs
+++ b/src/statement.rs
@@ -266,6 +266,20 @@ impl Bindable for i64 {
     }
 }
 
+impl Bindable for String {
+    #[inline]
+    fn bind(self, statement: &mut Statement, i: usize) -> Result<()> {
+        Bindable::bind(self.as_str(), statement, i)
+    }
+}
+
+impl<'l> Bindable for &'l String {
+    #[inline]
+    fn bind(self, statement: &mut Statement, i: usize) -> Result<()> {
+        Bindable::bind(self.as_str(), statement, i)
+    }
+}
+
 impl<'l> Bindable for &'l str {
     #[inline]
     fn bind(self, statement: &mut Statement, i: usize) -> Result<()> {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -222,6 +222,26 @@ fn statement_bind() {
     ok!(statement.bind(4, &[0x69u8, 0x42u8][..]));
     ok!(statement.bind(5, ()));
     assert_eq!(ok!(statement.next()), State::Done);
+
+    let statement = "INSERT INTO users VALUES (?, ?, ?, ?, ?)";
+    let mut statement = ok!(connection.prepare(statement));
+
+    ok!(statement.bind(1, 2i64));
+    ok!(statement.bind(2, "Bill".to_string()));
+    ok!(statement.bind(3, 69.42));
+    ok!(statement.bind(4, &[0x69u8, 0x42u8][..]));
+    ok!(statement.bind(5, ()));
+    assert_eq!(ok!(statement.next()), State::Done);
+
+    let statement = "INSERT INTO users VALUES (?, ?, ?, ?, ?)";
+    let mut statement = ok!(connection.prepare(statement));
+
+    ok!(statement.bind(1, 2i64));
+    ok!(statement.bind(2, &"Biff".to_string()));
+    ok!(statement.bind(3, 69.42));
+    ok!(statement.bind(4, &[0x69u8, 0x42u8][..]));
+    ok!(statement.bind(5, ()));
+    assert_eq!(ok!(statement.next()), State::Done);
 }
 
 #[test]


### PR DESCRIPTION
I noticed I couldn't bind String's directly without having to ".as_str()" them first.  I've added support to bind Strings and &Strings along with an updated test.