### PR TITLE
Allow reading TEXT columns with NULL values without panicking.

### DIFF
--- a/src/statement.rs
+++ b/src/statement.rs
@@ -343,9 +343,14 @@ impl Readable for String {
         unsafe {
             let pointer = ffi::sqlite3_column_text(statement.raw.0, i as c_int);
             if pointer.is_null() {
-                raise!("cannot read a text column");
+                if ffi::sqlite3_errcode(statement.raw.1) != ffi::SQLITE_OK {
+                    raise!("cannot read a text column");
+                }
+                Ok("".to_string())
             }
-            Ok(c_str_to_string!(pointer))
+            else {
+                Ok(c_str_to_string!(pointer))
+            }
         }
     }
 }


### PR DESCRIPTION
There is a case where `sqlite3_column_text` will return a NULL pointer that is entirely valid — when the table has a NULL value ([see table on this page](https://www.sqlite.org/c3ref/column_blob.html)), so without this patch, we get a panic despite everything actually being OK. This patch simply adds a check if there was an actual error when getting a NULL pointer back from `sqlite`.

(BLOB handling already deals with this case, so there is no need to change things there, either.)

To reproduce the original bug, simply try to SELECT a NULL value and `read::<String>()` the cursor.