### PR TITLE
Allow for reading blobs without allocating

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,7 +296,7 @@ mod statement;
 pub use connection::Connection;
 pub use connection::OpenFlags;
 pub use cursor::Cursor;
-pub use statement::{Bindable, Readable, State, Statement};
+pub use statement::{Bindable, FixedBytes, Readable, State, Statement};
 
 /// Open a read-write connection to a new or existing database.
 #[inline]


### PR DESCRIPTION
This introduces the `FixedBytes` type which implements `Readable`. This allows for allocating the space necessary to read `N` bytes out of a column onto the stack using an uninitialized byte array.

This can be useful in many scenarios, I primarily use it to avoid allocations for identifiers and timestamps which are fixed size blobs on the client side.

Naming is just suggestions at this point.