### PR TITLE
Row::read, Row::try_read documentation

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -118,7 +118,7 @@ impl<'l> From<CursorWithOwnership<'l>> for Statement<'l> {
 }
 
 impl Row {
-    /// Read the value in a column.
+    /// Read the value in a column. The first column is 0, the second is 1, ...
     ///
     /// # Panics
     ///
@@ -132,7 +132,7 @@ impl Row {
         self.try_read(column).unwrap()
     }
 
-    /// Try to read the value in a column.
+    /// Try to read the value in a column. The first column is 0, the second is 1, ...
     #[inline]
     pub fn try_read<'l, T, U>(&'l self, column: U) -> Result<T>
     where


### PR DESCRIPTION
Helpful to developers with no experience with sqlite to know that row columns are 0 indexed, other database row columns are usually 1 indexed and they can give the 0'th column access to db internal row id's.

Tried to use the style of Java's Resultset's documentation
e.g.
https://docs.oracle.com/javase/7/docs/api/java/sql/ResultSet.html#getBytes(int)