### PR TITLE
Implement From<Option<T>> for Value

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -81,6 +81,19 @@ implement!(String, String);
 implement!(&str, String);
 implement!((), Null);
 
+impl<T> From<Option<T>> for Value
+where
+    T: Into<Value>,
+    Value: From<T>,
+{
+    fn from(value: Option<T>) -> Self {
+        match value {
+            Some(data) => Value::from(data),
+            None => Self::Null,
+        }
+    }
+}
+
 macro_rules! implement(
     (@value $type:ty, $value:ident) => {
         impl TryFrom<Value> for $type {


### PR DESCRIPTION
Implements `From<Option<T>> for Value`, where `T: Into<Value>`. The `Some` case defers to the underlying `From` impl, while the `None` case is converted into `Value::Null`.

Partially resolves #61.