### PR TITLE
Replace sqlite3-sys with libsqlite3-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,14 +27,11 @@ keywords = ["database"]
 
 [features]
 default = ["linkage"]
-linkage = ["sqlite3-sys/linkage"]
+linkage = ["libsqlite3-sys/bundled"]
 
 [dependencies]
 libc = "0.2"
-
-[dependencies.sqlite3-sys]
-version = "0.14"
-default-features = false
+libsqlite3-sys = "0.26"
 
 [dev-dependencies]
 temporary = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@
 //! [1]: https://www.sqlite.org
 
 extern crate libc;
-extern crate sqlite3_sys as ffi;
+extern crate libsqlite3_sys as ffi;
 
 macro_rules! c_str_to_str(
     ($string:expr) => (::std::str::from_utf8(::std::ffi::CStr::from_ptr($string).to_bytes()));


### PR DESCRIPTION
Have you considered using the more widely-adopted `libsqlite3-sys` instead of the current `sqlite3-sys`?

Only one `*-sys` crate for a given library can exist in a project's dependency tree at once, so using a less-popular `*-sys` crate can cause some painful dependency conflicts downstream. 

For example, I want to use `arti-hyper` for Tor connections in an application I wrote. `arti-hyper` has a libsqlite3-sys dependency though, so I currently have to choose between using this excellent sqlite crate and having Tor support.

I would like to have my cake and eat it too :grin: Is this a change you'd be willing to consider? 