### PR TITLE
Support enable and loading sqlite extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 *.sqlite3
 Cargo.lock
 target

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -9,6 +9,27 @@ use common::setup_users;
 
 macro_rules! ok(($result:expr) => ($result.unwrap()));
 
+
+#[cfg(windows)]
+#[test]
+fn load_extension() {
+    let connection = ok!(Connection::open(":memory:"));
+    ok!(connection.enable_load_extension());
+    assert!(connection.load_extension("libsqlitefunctions.dll").is_err());
+}
+
+#[test]
+fn enable_load_extension() {
+    let connection = ok!(Connection::open(":memory:"));
+    ok!(connection.enable_load_extension());
+}
+
+#[test]
+fn disable_load_extension() {
+    let connection = ok!(Connection::open(":memory:"));
+    ok!(connection.disable_load_extension());
+}
+
 #[test]
 fn change_count() {
     let connection = setup_users(":memory:");

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -10,12 +10,11 @@ use common::setup_users;
 macro_rules! ok(($result:expr) => ($result.unwrap()));
 
 
-#[cfg(windows)]
 #[test]
 fn load_extension() {
     let connection = ok!(Connection::open(":memory:"));
     ok!(connection.enable_load_extension());
-    assert!(connection.load_extension("libsqlitefunctions.dll").is_err());
+    assert!(connection.load_extension("libsqlitefunctions").is_err());
 }
 
 #[test]


### PR DESCRIPTION
Possibility to allow load modules with missing sql functions like: stdev, square..

https://www.sqlite.org/contrib:
The files below are contributed by users and are not part of the standard SQLite package