### PR TITLE
Add Connection::last_insert_rowid

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -239,6 +239,11 @@ impl Connection {
         unsafe { ffi::sqlite3_total_changes(self.raw.0) as usize }
     }
 
+    #[inline]
+    pub fn last_insert_rowid(&self) -> i64 {
+        unsafe { ffi::sqlite3_last_insert_rowid(self.raw.0) }
+    }
+
     #[doc(hidden)]
     #[inline]
     pub fn as_raw(&self) -> *mut ffi::sqlite3 {

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -154,3 +154,15 @@ fn change_count() {
     assert_eq!(connection.change_count(), 2);
     assert_eq!(connection.total_change_count(), 5);
 }
+
+#[test]
+fn last_insert_rowid() {
+    let connection = ok!(Connection::open(":memory:"));
+    ok!(connection.execute("CREATE TABLE foo (value TEXT);"));
+
+    ok!(connection.execute("INSERT INTO foo VALUES ('bar');"));
+    assert_eq!(connection.last_insert_rowid(), 1);
+
+    ok!(connection.execute("INSERT INTO foo VALUES ('baz');"));
+    assert_eq!(connection.last_insert_rowid(), 2);
+}


### PR DESCRIPTION
Adds a wrapper around `ffi::sqlite3_last_insert_rowid` in `Connection`. 