### PR TITLE
Revised from previous PR90: Add contains function to RowIndex

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -30,6 +30,9 @@ pub struct Row {
 
 /// A type suitable for indexing columns in a row.
 pub trait RowIndex: std::fmt::Debug {
+    /// Check to see if the row contains a Column
+    fn contains(&self, row: &Row) -> bool;
+
     /// Identify the ordinal position.
     ///
     /// The first column has index 0.
@@ -198,6 +201,10 @@ impl RowIndex for &str {
         );
         row.column_mapping[self]
     }
+
+    fn contains(&self, row: &Row) -> bool {
+        row.column_mapping.contains_key(*self)
+    }
 }
 
 impl RowIndex for usize {
@@ -205,6 +212,10 @@ impl RowIndex for usize {
     fn index(self, row: &Row) -> usize {
         debug_assert!(self < row.values.len(), "the index is out of range");
         self
+    }
+
+    fn contains(&self, row: &Row) -> bool {
+        self < &row.values.len()
     }
 }
 

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -30,7 +30,7 @@ pub struct Row {
 
 /// A type suitable for indexing columns in a row.
 pub trait RowIndex: std::fmt::Debug {
-    /// Check to see if the row contains a Column
+    /// Check if the row contains a column.
     fn contains(&self, row: &Row) -> bool;
 
     /// Identify the ordinal position.
@@ -171,6 +171,17 @@ impl Row {
         U: RowIndex,
     {
         T::try_from(&self.values[column.index(self)])
+    }
+
+    /// Check to see if a given column exists within the row.
+    ///
+    /// In case of integer indices, the first column has index 0.
+    #[inline]
+    pub fn contains<U>(&self, column: U) -> bool
+    where
+        U: RowIndex,
+    {
+        column.contains(self)
     }
 }
 


### PR DESCRIPTION
- Added a "contains" function to the RowIndex trait
- Defined the contains funtion for &str and usize columns