### PR TITLE
Introduce a 'native' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ bundled = ["sqlite3-sys/bundled"]
 extension = []
 encryption = ["sqlite3-sys/encryption"]
 linkage = ["sqlite3-sys/linkage"]
+native = ["sqlite3-sys/native"]
 
 [dependencies.sqlite3-sys]
 version = "0.18"


### PR DESCRIPTION
The 'native' feature forces usage of the system sqlite, failing to compile if it is absent. This is distinct from the defaulting that the bundled sources as not used as fallback.

Depends-On: https://github.com/stainless-steel/sqlite3-sys/pull/10